### PR TITLE
Automated update of the homebrew tap - Tuneful (`Casks/tuneful.rb`)

### DIFF
--- a/.github/workflows/update_tuneful.yml
+++ b/.github/workflows/update_tuneful.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Check if a new release is available
         run: |
           current_version=$(grep -oP 'version "\K[^"]+' Casks/tuneful.rb)
-          if [ "$latest_tag" != "v$current_version" ]; then
-            echo "New release available: v$current_version -> $latest_tag"
+          if [ "$latest_tag" != "$current_version" ]; then
+            echo "New release available: $current_version -> $latest_tag"
             echo "Updating tuneful.rb"
             sed -i "s/version \".*\"/version \"$latest_tag\"/" Casks/tuneful.rb
             sed -i "s/sha256 \".*\"/sha256 \"$latest_sha256\"/" Casks/tuneful.rb

--- a/.github/workflows/update_tuneful.yml
+++ b/.github/workflows/update_tuneful.yml
@@ -35,3 +35,4 @@ jobs:
             git push
           else
             echo "No new release"
+          fi

--- a/.github/workflows/update_tuneful.yml
+++ b/.github/workflows/update_tuneful.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Get latest release info
+      - name: Get the latest release info
         run: |
           latest_release=$(curl -s https://api.github.com/repos/martinfekete10/Tuneful/releases/latest)
           latest_tag=$(echo $latest_release | jq -r '.tag_name')
@@ -20,11 +20,11 @@ jobs:
           echo "latest_tag=$latest_tag" >> $GITHUB_ENV
           echo "latest_sha256=$latest_sha256" >> $GITHUB_ENV
 
-      - name: Check if new release is available
+      - name: Check if a new release is available
         run: |
           current_version=$(grep -oP 'version "\K[^"]+' Casks/tuneful.rb)
           if [ "$latest_tag" != "v$current_version" ]; then
-            echo "New release available: $latest_tag"
+            echo "New release available: v$current_version -> $latest_tag"
             echo "Updating tuneful.rb"
             sed -i "s/version \".*\"/version \"$latest_tag\"/" Casks/tuneful.rb
             sed -i "s/sha256 \".*\"/sha256 \"$latest_sha256\"/" Casks/tuneful.rb
@@ -34,5 +34,5 @@ jobs:
             git commit -m "Update Tuneful to $latest_tag"
             git push
           else
-            echo "No new release"
+            echo "No new release."
           fi

--- a/.github/workflows/update_tuneful.yml
+++ b/.github/workflows/update_tuneful.yml
@@ -1,0 +1,37 @@
+name: Check and Update Tuneful Release
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # Runs daily at midnight UTC
+  workflow_dispatch:
+
+jobs:
+  check_release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Get latest release info
+        run: |
+          latest_release=$(curl -s https://api.github.com/repos/martinfekete10/Tuneful/releases/latest)
+          latest_tag=$(echo $latest_release | jq -r '.tag_name')
+          latest_sha256=$(curl -L https://github.com/martinfekete10/Tuneful/releases/download/$latest_tag/Tuneful.dmg | shasum -a 256 | awk '{print $1}')
+          echo "latest_tag=$latest_tag" >> $GITHUB_ENV
+          echo "latest_sha256=$latest_sha256" >> $GITHUB_ENV
+
+      - name: Check if new release is available
+        run: |
+          current_version=$(grep -oP 'version "\K[^"]+' Casks/tuneful.rb)
+          if [ "$latest_tag" != "v$current_version" ]; then
+            echo "New release available: $latest_tag"
+            echo "Updating tuneful.rb"
+            sed -i "s/version \".*\"/version \"$latest_tag\"/" Casks/tuneful.rb
+            sed -i "s/sha256 \".*\"/sha256 \"$latest_sha256\"/" Casks/tuneful.rb
+            git config --global user.name "github-actions[bot]"
+            git config --global user.email "github-actions[bot]@users.noreply.github.com"
+            git add Casks/tuneful.rb
+            git commit -m "Update Tuneful to $latest_tag"
+            git push
+          else
+            echo "No new release"

--- a/Casks/tuneful.rb
+++ b/Casks/tuneful.rb
@@ -1,6 +1,6 @@
 cask "tuneful" do
-  version "1.6.0"
-  sha256 "230e399133354310913a4f8bcda82ba91a92098f7f19560d0d32613388c08041"
+  version "v1.7.1"
+  sha256 "a7a125211fbc9042aa6ff1be4521ffd0c4f52a08f744a7671b3848bde6504610"
 
   desc "Native macOS menu bar playback control app for Spotify and Apple Music"
   homepage "https://github.com/martinfekete10/Tuneful"


### PR DESCRIPTION
This workflow will check and update the **Tuneful** tap - **`Casks/tuneful.rb`** **once every day** (as long as both the repos are public 😉). This would be very useful for people like me, who rely on homebrew to update all their formulae and Casks.

**Fixes** #1 